### PR TITLE
fix_issue-1: Add window control functionality

### DIFF
--- a/src/components/title-bar/TitleBar.css
+++ b/src/components/title-bar/TitleBar.css
@@ -9,6 +9,7 @@ div.title-bar {
   user-select: none;
   display: grid;
   grid-template-columns: 2.5rem minmax(0, 1fr) auto;
+  grid-template-rows: 1fr;
   align-items: center;
 
   > span {
@@ -19,11 +20,21 @@ div.title-bar {
     display: flex;
     flex-direction: row;
     gap: 0;
+    height: 100%;
 
     > button.window-control {
       width: 3rem;
       background-color: transparent;
       border: none;
+
+      &:hover {
+        background-color: #efefef;
+      }
+
+      &[data-action="close"]:hover {
+        background-color: red;
+        color: white;
+      }
     }
   }
 }

--- a/src/components/title-bar/TitleBar.tsx
+++ b/src/components/title-bar/TitleBar.tsx
@@ -4,17 +4,37 @@
   September 29th, 2025
 */
 
+import React from 'react';
+
+import { getCurrentWindow } from '@tauri-apps/api/window';
+
+
 import './TitleBar.css';
 
 const TitleBar: React.FC = () => {
+
+  const window = getCurrentWindow();
+
+  function handleMinimize(): void {
+    window.minimize();
+  }
+
+  function handleToggleMaximize(): void {
+    window.toggleMaximize();
+  }
+
+  function handleClose(): void {
+    window.close();
+  }
+
   return (
     <div className="title-bar" data-tauri-drag-region>
       <span className="icon"></span>
       <span className="title">Something something</span>
       <div className="window-controls">
-        <button className="window-control codicon codicon-chrome-minimize"></button>
-        <button className="window-control codicon codicon-chrome-maximize"></button>
-        <button className="window-control codicon codicon-chrome-close"></button>
+        <button className="window-control codicon codicon-chrome-minimize" onClick={handleMinimize}></button>
+        <button className="window-control codicon codicon-chrome-maximize" onClick={handleToggleMaximize}></button>
+        <button data-action="close" className="window-control codicon codicon-chrome-close" onClick={handleClose}></button>
       </div>
     </div>
   );


### PR DESCRIPTION
# Summary
Add basic functionality for window controls and a bit of styling to make it easier to see when they are being hovered.

# Pending
- Further work is needed to ensure that the correct icon is displayed for the toggle maximize button. Currently only the maximize icon is shown.
- There are currently no styling options at runtime.
- Controls are keyboard accesible through tab-based navigation. Should remove that capability